### PR TITLE
Handle empty tensors when summing reacher costs

### DIFF
--- a/src/curobo/rollout/arm_reacher.py
+++ b/src/curobo/rollout/arm_reacher.py
@@ -550,11 +550,37 @@ class ArmReacher(ArmBase, ArmReacherConfig):
 
 @get_torch_jit_decorator()
 def cat_sum_reacher(tensor_list: List[torch.Tensor]):
-    cat_tensor = torch.sum(torch.stack(tensor_list, dim=0), dim=0)
+    valid_tensors: List[torch.Tensor] = []
+    if len(tensor_list) > 0:
+        reference_tensor: torch.Tensor = tensor_list[0]
+    else:
+        reference_tensor = torch.zeros(0)
+
+    for tensor in tensor_list:
+        if tensor.numel() > 0:
+            valid_tensors.append(tensor)
+
+    if len(valid_tensors) == 0:
+        return torch.zeros_like(reference_tensor)
+
+    cat_tensor = torch.sum(torch.stack(valid_tensors, dim=0), dim=0)
     return cat_tensor
 
 
 @get_torch_jit_decorator()
 def cat_sum_horizon_reacher(tensor_list: List[torch.Tensor]):
-    cat_tensor = torch.sum(torch.stack(tensor_list, dim=0), dim=(0, -1))
+    valid_tensors: List[torch.Tensor] = []
+    if len(tensor_list) > 0:
+        reference_tensor: torch.Tensor = tensor_list[0]
+    else:
+        reference_tensor = torch.zeros(0)
+
+    for tensor in tensor_list:
+        if tensor.numel() > 0:
+            valid_tensors.append(tensor)
+
+    if len(valid_tensors) == 0:
+        return torch.zeros_like(reference_tensor)
+
+    cat_tensor = torch.sum(torch.stack(valid_tensors, dim=0), dim=(0, -1))
     return cat_tensor

--- a/src/curobo/util_file.py
+++ b/src/curobo/util_file.py
@@ -122,7 +122,7 @@ def load_yaml(file_path: Union[str, Dict]) -> Dict:
         Dict: Dictionary containing yaml file content.
     """
     if isinstance(file_path, str):
-        with open(file_path) as file_p:
+        with open(file_path, encoding="utf-8") as file_p:
             yaml_params = yaml.load(file_p, Loader=Loader)
     else:
         yaml_params = file_path
@@ -136,7 +136,7 @@ def write_yaml(data: Dict, file_path: str):
         data: Dictionary to write to yaml file.
         file_path: Path to write the yaml file.
     """
-    with open(file_path, "w") as file:
+    with open(file_path, "w", encoding="utf-8") as file:
         yaml.dump(data, file)
 
 


### PR DESCRIPTION
## Summary
- guard the reacher cost aggregation helpers to ignore empty tensors and fall back to zero tensors when no valid entries remain

## Testing
- python -m pytest tests/motion_gen_test.py -k "reacher" -q *(fails: ModuleNotFoundError: No module named 'curobo')*
- PYTHONPATH=src python -m pytest tests/motion_gen_test.py -k "reacher" -q *(fails: ModuleNotFoundError: No module named 'setuptools_scm')*

------
https://chatgpt.com/codex/tasks/task_e_68e0d9a941fc83289af819c042afc43b